### PR TITLE
set allergens state via useEffect

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -70,7 +70,6 @@ function allergenTimeSortCallback(a, b) {
 }
 
 function loadJSONfromLocal(key) {
-  if (typeof window !== "undefined") {
     const storedTimes = JSON.parse(window.localStorage.getItem(key));
     if (storedTimes) {
       return storedTimes.map(({ name, time }) => {
@@ -80,8 +79,6 @@ function loadJSONfromLocal(key) {
     } else {
       return null;
     }
-  }
-  return [];
 }
 
 function storeJSONinLocal(key, value) {

--- a/app/page.js
+++ b/app/page.js
@@ -5,14 +5,18 @@ import Since from "./components/since";
 let allergenNames = ["Milk", "Eggs", "Nuts", "Fish", "Wheat", "Soy", "Sesame"];
 
 export default function Home() {
-  const [allergens, setAllergens] = useState(loadAllergensOrDefault());
+  const [allergens, setAllergens] = useState([]);
+
+  useEffect(() => {
+    setAllergens(loadAllergensOrDefault())
+  }, [])
 
   function updateTime(targetAllergen) {
     const time = new Date();
     const updatedAllergens = allergens
       .map((allergen) => {
         if (allergen.name === targetAllergen) {
-          return { name: targetAllergen, time };
+          return {...allergen, time};
         } else {
           return allergen;
         }
@@ -34,7 +38,6 @@ export default function Home() {
               <li key={name}>
                 <p
                   className="font-bold text-lg"
-                  suppressHydrationWarning={true}
                 >
                   {name}
                 </p>
@@ -69,10 +72,16 @@ function allergenTimeSortCallback(a, b) {
 function loadJSONfromLocal(key) {
   if (typeof window !== "undefined") {
     const storedTimes = JSON.parse(window.localStorage.getItem(key));
-    return storedTimes.map(({ name, time }) => {
-      return { name, time: time ? new Date(time) : null };
-    });
+    if (storedTimes) {
+      return storedTimes.map(({ name, time }) => {
+        console.log("loaded: ", name, time)
+        return { name, time: time ? new Date(time) : null };
+      });
+    } else {
+      return null;
+    }
   }
+  return [];
 }
 
 function storeJSONinLocal(key, value) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "npx serve@latest out",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
This removes the need to suppress a hydration warning, as there will be no pre-rendered allergen list. The call to local storage has been added to a useEffect hook which will only run on mounting the page. This also fixes the bug that throws an exception when viewing the page without previously having allergen data in local storage. 

It also changes the start script to be compatible with the next.js config required for hosting with Github Pages.